### PR TITLE
remove older io.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ node_js:
   - v5
   - v4
   - iojs-v3
-  - iojs-v2
-  - iojs-v1
   - '0.12'
   - '0.10'
 before_install:


### PR DESCRIPTION
To reduce Travis CI processing time (and load).
